### PR TITLE
Fixed issue reporting links

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,5 +13,5 @@ To **give feedback or suggestions**, please also create an [issue][new-issue], b
 Please be actionable, specific, and kind in your feedback. We'll reply to you as soon as we are able.
 
 [report-bugs-gh]: https://coenjacobs.me/2013/12/06/effective-bug-reports-on-github/
-[new-issue]: /issues/new
-[issue-template]: ./github/ISSUE_TEMPLATE.md
+[new-issue]: https://github.com/LearnersGuild/los/issues/new
+[issue-template]: /.github/ISSUE_TEMPLATE.md


### PR DESCRIPTION
- `/issue/new` was getting resolved to a file path in the repo instead of issues page
- Off by one error on the period for the template link
